### PR TITLE
Add the `parameters` argument for various `list()` methods

### DIFF
--- a/src/Channels.js
+++ b/src/Channels.js
@@ -54,12 +54,12 @@ export default class Channels extends Request {
     return super.sendRequest('post', '/channels.leave', parameters);
   }
 
-  listJoined() {
-    return super.sendRequest('get', '/channels.list.joined');
+  listJoined(parameters = {}) {
+    return super.sendRequest('get', '/channels.list.joined', parameters);
   }
 
-  list() {
-    return super.sendRequest('get', '/channels.list');
+  list(parameters = {}) {
+    return super.sendRequest('get', '/channels.list', parameters);
   }
 
   open(parameters) {

--- a/src/Groups.js
+++ b/src/Groups.js
@@ -50,8 +50,8 @@ export default class Groups extends Request {
     return super.sendRequest('post', '/groups.leave', parameters);
   }
 
-  list() {
-    return super.sendRequest('get', '/groups.list');
+  list(parameters = {}) {
+    return super.sendRequest('get', '/groups.list', parameters);
   }
 
   open(parameters) {

--- a/src/Im.js
+++ b/src/Im.js
@@ -9,12 +9,12 @@ export default class Im extends Request {
     return super.sendRequest('get', '/im.history', parameters, { authenticate: true, requestType: 'queryString' });
   }
 
-  listEveryone() {
-    return super.sendRequest('get', '/im.list.everyone');
+  listEveryone(parameters = {}) {
+    return super.sendRequest('get', '/im.list.everyone', parameters);
   }
 
-  list() {
-    return super.sendRequest('get', '/im.list');
+  list(parameters = {}) {
+    return super.sendRequest('get', '/im.list', parameters);
   }
 
   messagesOthers(parameters) {

--- a/src/Integration.js
+++ b/src/Integration.js
@@ -6,8 +6,8 @@ export default class Integration extends Request {
     return super.sendRequest('post', '/integrations.create', parameters);
   }
 
-  list() {
-    return super.sendRequest('get', '/integrations.list');
+  list(parameters = {}) {
+    return super.sendRequest('get', '/integrations.list', parameters);
   }
 
   remove(parameters) {

--- a/src/Users.js
+++ b/src/Users.js
@@ -18,8 +18,8 @@ export default class Users extends Request {
     return super.sendRequest('get', '/users.info', parameters, { authenticate: true, requestType: 'queryString' });
   }
 
-  list() {
-    return super.sendRequest('get', '/users.list', {});
+  list(parameters = {}) {
+    return super.sendRequest('get', '/users.list', parameters);
   }
 
   setAvatar(parameters) {


### PR DESCRIPTION
This change will automatically add support for the `query` and `fields` parameters as seen in https://rocket.chat/docs/developer-guides/rest-api/query-and-fields-info/